### PR TITLE
remove plist_options

### DIFF
--- a/Formula/noclamshell.rb
+++ b/Formula/noclamshell.rb
@@ -8,7 +8,11 @@ class Noclamshell < Formula
     bin.install "noclamshell"
   end
 
-  plist_options manual: "noclamshell"
+  service do
+    run [opt_bin/"noclamshell", "--no-daemon"]
+    keep_alive true
+    working_dir HOMEBREW_PREFIX
+  end
 
   def plist; <<~XML
     <?xml version="1.0" encoding="UTF-8"?>


### PR DESCRIPTION
I'm not 100% certain if this is the proper way to fix the deprecation of plist_options, this follows the patterns from some other examples. Any feedback is welcome! (this is _super_ not my area of expertise)