### PR TITLE
Use service block to create plist

### DIFF
--- a/Formula/noclamshell.rb
+++ b/Formula/noclamshell.rb
@@ -8,25 +8,11 @@ class Noclamshell < Formula
     bin.install "noclamshell"
   end
 
-  plist_options manual: "noclamshell"
-
-  def plist; <<~XML
-    <?xml version="1.0" encoding="UTF-8"?>
-    <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
-    <plist version="1.0">
-      <dict>
-        <key>Label</key><string>#{plist_name}</string>
-        <key>ThrottleInterval</key> <integer>2</integer>
-        <key>KeepAlive</key> <true/>
-        <key>ProgramArguments</key>
-          <array>
-            <string>bash</string>
-            <string>-c</string>
-            <string>#{opt_bin}/noclamshell</string>
-          </array>
-      </dict>
-    </plist>
-    XML
+  service do
+    run opt_bin/"noclamshell"
+    keep_alive true
+    run_type :interval
+    interval 1
   end
 
   test do


### PR DESCRIPTION
Homebrew has introduced [a new service block](https://docs.brew.sh/Formula-Cookbook#service-files) and is complaining about using "manual" plists. This switches the formula to use the former.

The [`Homebrew::Service`](https://rubydoc.brew.sh/Homebrew/Service.html) (a class backing service blocks) doesn't seem to have a support for `RestartInterval` at this moment. I decided to use `:interval` which translates to `StartInterval`. According to [SO](https://apple.stackexchange.com/questions/346694/what-is-the-difference-between-interval-and-throttleinterval-in-launchd-plist) there seems to be a subtle difference between these two.

In my testing (very limitted so far) I seem to see a longer period between I close the lid of the laptop and when external monitors go off. Don't have any supporting data (benchmark or anything), but I decided to reduce the interval to 1s anyway.

fixes #2 and #3 (supercedes the latter)